### PR TITLE
fix name error in yandex_cleanweb.rb

### DIFF
--- a/lib/yandex_cleanweb.rb
+++ b/lib/yandex_cleanweb.rb
@@ -22,7 +22,7 @@ module YandexCleanweb
 
       if spam_flag == 'yes'
         links = doc.xpath('//check-spam-result/links').map { |el|
-          [attributes["url"], attributes["spam_flag"] == 'yes']
+          [el.attributes["url"], el.attributes["spam_flag"] == 'yes']
         }
 
         { id: request_id, links: links }


### PR DESCRIPTION
Попробовал примеры из ридми - выдало `NameError: undefined local variable or method `attributes' for YandexCleanweb:Module`

Надеюсь, я правильно понял, что там имелось в виду.
